### PR TITLE
Decrease the required version of ActiveSupport.

### DIFF
--- a/ddr-antivirus.gemspec
+++ b/ddr-antivirus.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activesupport", "~> 4.0"
+  spec.add_dependency "activesupport", ">= 2.1"
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "clamav"


### PR DESCRIPTION
- There's no reason to require such a high version, mattr_accessor has
  been available since 2.1.
- I can't install clamav with Ruby higher than 1.9.3. Rails 4 requires
  Ruby 2+. This change make it so that ddr-antivirus can use clamav on
  older versions of Rails.
